### PR TITLE
Agregar consolidado de ensayos y proyección de aciertos

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,27 @@ python procesar_respuestas.py
 ```
 
 Los archivos de salida se generan en la raíz del repositorio.
+
+## `consolidar_rendiciones.py`
+
+Recorre todos los archivos dentro de `csv_ensayos/` y genera
+`resumen_rendiciones.csv`, donde para cada estudiante se indica qué
+examen rindió, el puntaje obtenido y si aún no lo ha realizado (`NR`).
+
+### Uso
+
+```bash
+python consolidar_rendiciones.py
+```
+
+## `proyeccion_correctas.py`
+
+Estima cuántas preguntas correctas podría obtener cada estudiante en los
+exámenes que todavía no ha rendido, basándose en su desempeño previo.
+El resultado se guarda en `proyeccion_preguntas_correctas.csv`.
+
+### Uso
+
+```bash
+python proyeccion_correctas.py
+```

--- a/consolidar_rendiciones.py
+++ b/consolidar_rendiciones.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Genera un resumen de rendiciones y puntajes por estudiante.
+
+Recorre todos los archivos CSV en ``csv_ensayos/`` y produce un archivo
+``resumen_rendiciones.csv`` con las columnas ``StudentID,FirstName,LastName,Exam,Status,Score``.
+Si un estudiante no ha rendido un examen se marca como ``NR`` y el
+puntaje queda vacío.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict, Set
+
+INPUT_DIR = Path("csv_ensayos")
+OUTPUT_FILE = Path("resumen_rendiciones.csv")
+
+
+def reunir_datos() -> tuple[dict[str, dict[str, object]], Set[str]]:
+    """Lee todos los CSV y consolida la información."""
+    estudiantes: dict[str, dict[str, object]] = {}
+    examenes: Set[str] = set()
+
+    for ruta in sorted(INPUT_DIR.glob("*.csv")):
+        with ruta.open(newline="", encoding="utf-8-sig") as f:
+            reader = csv.DictReader(f)
+            for fila in reader:
+                examen = fila.get("QuizName") or ruta.stem
+                examenes.add(examen)
+                sid = fila.get("StudentID", "").strip()
+                nombre = fila.get("FirstName", "").strip()
+                apellido = fila.get("LastName", "").strip()
+                try:
+                    puntaje = float(fila.get("Earned Points", "") or 0)
+                except ValueError:
+                    puntaje = 0.0
+
+                info = estudiantes.setdefault(
+                    sid, {"FirstName": nombre, "LastName": apellido, "scores": {}}
+                )
+                info["FirstName"] = info.get("FirstName") or nombre
+                info["LastName"] = info.get("LastName") or apellido
+                scores: Dict[str, float] = info["scores"]  # type: ignore[assignment]
+                scores[examen] = puntaje
+    return estudiantes, examenes
+
+
+def generar_resumen(
+    estudiantes: dict[str, dict[str, object]], examenes: Set[str]
+) -> list[dict[str, object]]:
+    """Crea las filas para el CSV de salida."""
+    filas: list[dict[str, object]] = []
+    for sid, info in estudiantes.items():
+        nombre = info["FirstName"]
+        apellido = info["LastName"]
+        scores: Dict[str, float] = info["scores"]  # type: ignore[assignment]
+        for examen in sorted(examenes):
+            if examen in scores:
+                filas.append(
+                    {
+                        "StudentID": sid,
+                        "FirstName": nombre,
+                        "LastName": apellido,
+                        "Exam": examen,
+                        "Status": "R",
+                        "Score": scores[examen],
+                    }
+                )
+            else:
+                filas.append(
+                    {
+                        "StudentID": sid,
+                        "FirstName": nombre,
+                        "LastName": apellido,
+                        "Exam": examen,
+                        "Status": "NR",
+                        "Score": "",
+                    }
+                )
+    return filas
+
+
+def escribir_csv(filas: list[dict[str, object]]) -> None:
+    campos = ["StudentID", "FirstName", "LastName", "Exam", "Status", "Score"]
+    with OUTPUT_FILE.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=campos)
+        writer.writeheader()
+        writer.writerows(filas)
+
+
+def main() -> None:
+    estudiantes, examenes = reunir_datos()
+    resumen = generar_resumen(estudiantes, examenes)
+    escribir_csv(resumen)
+
+
+if __name__ == "__main__":
+    main()

--- a/proyeccion_correctas.py
+++ b/proyeccion_correctas.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Estima preguntas correctas para ensayos no rendidos.
+
+Calcula el porcentaje promedio de aciertos por estudiante y lo aplica a
+los exámenes que aún no ha rendido para proyectar la cantidad de
+respuestas correctas. El resultado se guarda en
+``proyeccion_preguntas_correctas.csv``.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict, Set
+
+INPUT_DIR = Path("csv_ensayos")
+OUTPUT_FILE = Path("proyeccion_preguntas_correctas.csv")
+
+
+def _to_float(valor: str | None) -> float:
+    try:
+        return float(valor or 0)
+    except ValueError:
+        return 0.0
+
+
+def leer_rendimientos() -> tuple[dict[str, dict[str, object]], Dict[str, int]]:
+    estudiantes: dict[str, dict[str, object]] = {}
+    preguntas_por_examen: Dict[str, int] = {}
+
+    for ruta in sorted(INPUT_DIR.glob("*.csv")):
+        with ruta.open(newline="", encoding="utf-8-sig") as f:
+            reader = csv.DictReader(f)
+            filas = list(reader)
+        if not filas:
+            continue
+
+        examen = filas[0].get("QuizName") or ruta.stem
+        preguntas = sum(
+            1
+            for clave, valor in filas[0].items()
+            if clave.startswith("Points") and _to_float(valor) > 0
+        )
+        preguntas_por_examen[examen] = preguntas
+
+        for fila in filas:
+            sid = fila.get("StudentID", "").strip()
+            nombre = fila.get("FirstName", "").strip()
+            apellido = fila.get("LastName", "").strip()
+            earned = _to_float(fila.get("Earned Points", ""))
+            possible = _to_float(fila.get("Possible Points", ""))
+            porcentaje = earned / possible if possible else 0.0
+
+            info = estudiantes.setdefault(
+                sid,
+                {
+                    "FirstName": nombre,
+                    "LastName": apellido,
+                    "percentages": [],
+                    "exams": set(),
+                },
+            )
+            info["FirstName"] = info.get("FirstName") or nombre
+            info["LastName"] = info.get("LastName") or apellido
+            porcentajes: list[float] = info["percentages"]  # type: ignore[assignment]
+            porcentajes.append(porcentaje)
+            examenes: Set[str] = info["exams"]  # type: ignore[assignment]
+            examenes.add(examen)
+
+    return estudiantes, preguntas_por_examen
+
+
+def proyectar(
+    estudiantes: dict[str, dict[str, object]], preguntas_por_examen: Dict[str, int]
+) -> list[dict[str, object]]:
+    filas: list[dict[str, object]] = []
+    for sid, info in estudiantes.items():
+        nombre = info["FirstName"]
+        apellido = info["LastName"]
+        porcentajes: list[float] = info["percentages"]  # type: ignore[assignment]
+        examenes: Set[str] = info["exams"]  # type: ignore[assignment]
+        promedio = sum(porcentajes) / len(porcentajes) if porcentajes else 0.0
+        for examen, preguntas in preguntas_por_examen.items():
+            if examen not in examenes:
+                proyectado = round(promedio * preguntas, 2)
+                filas.append(
+                    {
+                        "StudentID": sid,
+                        "FirstName": nombre,
+                        "LastName": apellido,
+                        "Exam": examen,
+                        "ProjectedCorrect": proyectado,
+                    }
+                )
+    return filas
+
+
+def escribir_csv(filas: list[dict[str, object]]) -> None:
+    campos = ["StudentID", "FirstName", "LastName", "Exam", "ProjectedCorrect"]
+    with OUTPUT_FILE.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=campos)
+        writer.writeheader()
+        writer.writerows(filas)
+
+
+def main() -> None:
+    estudiantes, preguntas_por_examen = leer_rendimientos()
+    filas = proyectar(estudiantes, preguntas_por_examen)
+    escribir_csv(filas)
+
+
+if __name__ == "__main__":
+    main()

--- a/proyeccion_preguntas_correctas.csv
+++ b/proyeccion_preguntas_correctas.csv
@@ -1,0 +1,167 @@
+StudentID,FirstName,LastName,Exam,ProjectedCorrect
+502,Gabriela Paz,Acuña,M1 4 Moraleja 2025,13.08
+502,Gabriela Paz,Acuña,M2 4 Moraleja 2025,7.55
+502,Gabriela Paz,Acuña,M2 5 Moraleja 2025,10.06
+503,Cristoba,Arriagada,M1 2 Moraleja 2025,15.8
+503,Cristoba,Arriagada,M1 4 Moraleja 2025,15.8
+503,Cristoba,Arriagada,M2 4 Moraleja 2025,9.11
+503,Cristoba,Arriagada,M2 5 Moraleja 2025,12.15
+524,Joshua Adolfo,Bravo,M2 1 Moraleja 2025,4.37
+524,Joshua Adolfo,Bravo,M2 4 Moraleja 2025,8.19
+524,Joshua Adolfo,Bravo,M2 5 Moraleja 2025,10.92
+505,Agustina Belén,Carrera,M1 2 Moraleja 2025,18.2
+505,Agustina Belén,Carrera,M1 4 Moraleja 2025,18.2
+505,Agustina Belén,Carrera,M2 1 Moraleja 2025,5.6
+505,Agustina Belén,Carrera,M2 4 Moraleja 2025,10.5
+505,Agustina Belén,Carrera,M2 5 Moraleja 2025,14.0
+508,Isidora Paz,Catalán,M1 4 Moraleja 2025,8.52
+508,Isidora Paz,Catalán,M2 1 Moraleja 2025,2.62
+508,Isidora Paz,Catalán,M2 4 Moraleja 2025,4.92
+508,Isidora Paz,Catalán,M2 5 Moraleja 2025,6.56
+514,Juan Esteban,Cruz,M1 2 Moraleja 2025,21.02
+514,Juan Esteban,Cruz,M1 4 Moraleja 2025,21.02
+514,Juan Esteban,Cruz,M2 1 Moraleja 2025,6.47
+514,Juan Esteban,Cruz,M2 4 Moraleja 2025,12.12
+514,Juan Esteban,Cruz,M2 5 Moraleja 2025,16.17
+511,Josefa,Fontecilla,M1 4 Moraleja 2025,17.33
+511,Josefa,Fontecilla,M2 1 Moraleja 2025,5.33
+511,Josefa,Fontecilla,M2 4 Moraleja 2025,10.0
+511,Josefa,Fontecilla,M2 5 Moraleja 2025,13.33
+528,Ignacia Isabela,Galleguillos,M1 4 Moraleja 2025,7.92
+528,Ignacia Isabela,Galleguillos,M1 Invierno Ad.26,17.36
+506,Alejandra,García,M1 2 Moraleja 2025,17.33
+506,Alejandra,García,M1 4 Moraleja 2025,17.33
+506,Alejandra,García,M2 1 Moraleja 2025,5.33
+506,Alejandra,García,M2 4 Moraleja 2025,10.0
+506,Alejandra,García,M2 5 Moraleja 2025,13.33
+513,Josefina Andrea,Gutierrez,M1 2 Moraleja 2025,16.68
+513,Josefina Andrea,Gutierrez,M1 4 Moraleja 2025,16.68
+513,Josefina Andrea,Gutierrez,M2 1 Moraleja 2025,5.13
+513,Josefina Andrea,Gutierrez,M2 4 Moraleja 2025,9.62
+513,Josefina Andrea,Gutierrez,M2 5 Moraleja 2025,12.83
+527,Javier Alejando,Huechucura,M1 2 Moraleja 2025,6.93
+527,Javier Alejando,Huechucura,M1 4 Moraleja 2025,6.93
+527,Javier Alejando,Huechucura,M1 Invierno Ad.26,15.2
+527,Javier Alejando,Huechucura,M2 1 Moraleja 2025,2.13
+527,Javier Alejando,Huechucura,M2 4 Moraleja 2025,4.0
+527,Javier Alejando,Huechucura,M2 5 Moraleja 2025,5.33
+525,Agustina Paz,Larenas,M1 2 Moraleja 2025,9.1
+525,Agustina Paz,Larenas,M1 4 Moraleja 2025,9.1
+525,Agustina Paz,Larenas,M1 Invierno Ad.26,19.95
+525,Agustina Paz,Larenas,M2 1 Moraleja 2025,2.8
+525,Agustina Paz,Larenas,M2 4 Moraleja 2025,5.25
+525,Agustina Paz,Larenas,M2 5 Moraleja 2025,7.0
+509,Simón Augusto,Lazo,M1 2 Moraleja 2025,14.73
+509,Simón Augusto,Lazo,M1 4 Moraleja 2025,14.73
+509,Simón Augusto,Lazo,M1 Invierno Ad.26,32.3
+509,Simón Augusto,Lazo,M2 1 Moraleja 2025,4.53
+509,Simón Augusto,Lazo,M2 4 Moraleja 2025,8.5
+509,Simón Augusto,Lazo,M2 5 Moraleja 2025,11.33
+553,Paula,Lizana,M1 4 Moraleja 2025,16.87
+553,Paula,Lizana,M1 Invierno Ad.26,36.98
+510,Trinidad Renata,Lorca,M1 4 Moraleja 2025,13.87
+510,Trinidad Renata,Lorca,M2 1 Moraleja 2025,4.27
+510,Trinidad Renata,Lorca,M2 4 Moraleja 2025,8.0
+510,Trinidad Renata,Lorca,M2 5 Moraleja 2025,10.67
+501,Florencia Paz,Olguín,M1 2 Moraleja 2025,17.55
+501,Florencia Paz,Olguín,M1 4 Moraleja 2025,17.55
+501,Florencia Paz,Olguín,M2 1 Moraleja 2025,5.4
+501,Florencia Paz,Olguín,M2 4 Moraleja 2025,10.12
+501,Florencia Paz,Olguín,M2 5 Moraleja 2025,13.5
+516,Ignacio Andrés,Ortiz,M1 4 Moraleja 2025,19.93
+516,Ignacio Andrés,Ortiz,M2 1 Moraleja 2025,6.13
+516,Ignacio Andrés,Ortiz,M2 4 Moraleja 2025,11.5
+516,Ignacio Andrés,Ortiz,M2 5 Moraleja 2025,15.33
+554,Carla,Parraguez,M1 2 Moraleja 2025,15.6
+554,Carla,Parraguez,M1 4 Moraleja 2025,15.6
+554,Carla,Parraguez,M1 Invierno Ad.26,34.2
+554,Carla,Parraguez,M2 1 Moraleja 2025,4.8
+554,Carla,Parraguez,M2 4 Moraleja 2025,9.0
+554,Carla,Parraguez,M2 5 Moraleja 2025,12.0
+550,Santiago,Quilodrán,M1 4 Moraleja 2025,24.48
+550,Santiago,Quilodrán,M1 Invierno Ad.26,53.67
+550,Santiago,Quilodrán,M2 1 Moraleja 2025,7.53
+550,Santiago,Quilodrán,M2 4 Moraleja 2025,14.12
+550,Santiago,Quilodrán,M2 5 Moraleja 2025,18.83
+551,Sofía,Quilodrán,M1 4 Moraleja 2025,24.05
+551,Sofía,Quilodrán,M1 Invierno Ad.26,52.73
+551,Sofía,Quilodrán,M2 1 Moraleja 2025,7.4
+551,Sofía,Quilodrán,M2 4 Moraleja 2025,13.88
+551,Sofía,Quilodrán,M2 5 Moraleja 2025,18.5
+552,José,Reyes,M1 2 Moraleja 2025,20.8
+552,José,Reyes,M1 4 Moraleja 2025,20.8
+552,José,Reyes,M1 Invierno Ad.26,45.6
+552,José,Reyes,M2 1 Moraleja 2025,6.4
+552,José,Reyes,M2 4 Moraleja 2025,12.0
+552,José,Reyes,M2 5 Moraleja 2025,16.0
+533,Martín Ignacio,Robles,M1 2 Moraleja 2025,15.17
+533,Martín Ignacio,Robles,M1 4 Moraleja 2025,15.17
+533,Martín Ignacio,Robles,M2 1 Moraleja 2025,4.67
+533,Martín Ignacio,Robles,M2 4 Moraleja 2025,8.75
+533,Martín Ignacio,Robles,M2 5 Moraleja 2025,11.67
+530,Josefa Trinidad,Rojas,M1 4 Moraleja 2025,17.18
+530,Josefa Trinidad,Rojas,M1 Invierno Ad.26,37.66
+504,Emilia Loreto,Sotelo,M1 4 Moraleja 2025,16.9
+504,Emilia Loreto,Sotelo,M2 1 Moraleja 2025,5.2
+504,Emilia Loreto,Sotelo,M2 4 Moraleja 2025,9.75
+504,Emilia Loreto,Sotelo,M2 5 Moraleja 2025,13.0
+532,Antonia,Tobar,M1 4 Moraleja 2025,13.43
+532,Antonia,Tobar,M1 Invierno Ad.26,29.44
+532,Antonia,Tobar,M2 5 Moraleja 2025,10.33
+531,Renato Alonso,Urrucelqui,M1 2 Moraleja 2025,18.85
+531,Renato Alonso,Urrucelqui,M1 4 Moraleja 2025,18.85
+531,Renato Alonso,Urrucelqui,M2 1 Moraleja 2025,5.8
+531,Renato Alonso,Urrucelqui,M2 4 Moraleja 2025,10.88
+531,Renato Alonso,Urrucelqui,M2 5 Moraleja 2025,14.5
+517,Agustina Beatriz,Valenzuela,M1 2 Moraleja 2025,16.9
+517,Agustina Beatriz,Valenzuela,M2 1 Moraleja 2025,5.2
+517,Agustina Beatriz,Valenzuela,M2 4 Moraleja 2025,9.75
+517,Agustina Beatriz,Valenzuela,M2 5 Moraleja 2025,13.0
+507,Trinidad del Pilar,Vargas,M1 4 Moraleja 2025,11.56
+507,Trinidad del Pilar,Vargas,M2 1 Moraleja 2025,3.56
+507,Trinidad del Pilar,Vargas,M2 4 Moraleja 2025,6.67
+507,Trinidad del Pilar,Vargas,M2 5 Moraleja 2025,8.89
+518,Matías Alejandro,Arriagada,M1 1 Moraleja 2025,7.73
+518,Matías Alejandro,Arriagada,M1 4 Moraleja 2025,6.93
+518,Matías Alejandro,Arriagada,M1 Invierno Ad.26,15.2
+518,Matías Alejandro,Arriagada,M2 1 Moraleja 2025,2.13
+518,Matías Alejandro,Arriagada,M2 4 Moraleja 2025,4.0
+518,Matías Alejandro,Arriagada,M2 5 Moraleja 2025,5.33
+556,Valentina,Medina,M1 1 Moraleja 2025,20.23
+556,Valentina,Medina,M1 4 Moraleja 2025,18.14
+556,Valentina,Medina,M1 Invierno Ad.26,39.77
+556,Valentina,Medina,M2 4 Moraleja 2025,10.47
+556,Valentina,Medina,M2 5 Moraleja 2025,13.95
+557,Gaspar,Morales Becerra,M1 1 Moraleja 2025,15.22
+557,Gaspar,Morales Becerra,M1 4 Moraleja 2025,13.65
+557,Gaspar,Morales Becerra,M2 1 Moraleja 2025,4.2
+557,Gaspar,Morales Becerra,M2 4 Moraleja 2025,7.87
+557,Gaspar,Morales Becerra,M2 5 Moraleja 2025,10.5
+515,Francisca,Ortiz,M1 1 Moraleja 2025,18.85
+515,Francisca,Ortiz,M1 4 Moraleja 2025,16.9
+515,Francisca,Ortiz,M2 1 Moraleja 2025,5.2
+515,Francisca,Ortiz,M2 4 Moraleja 2025,9.75
+515,Francisca,Ortiz,M2 5 Moraleja 2025,13.0
+526,Josefa Valentina,Quiroga,M1 1 Moraleja 2025,18.85
+526,Josefa Valentina,Quiroga,M1 Invierno Ad.26,37.05
+526,Josefa Valentina,Quiroga,M2 1 Moraleja 2025,5.2
+526,Josefa Valentina,Quiroga,M2 4 Moraleja 2025,9.75
+526,Josefa Valentina,Quiroga,M2 5 Moraleja 2025,13.0
+555,Vicente,Yañez,M1 1 Moraleja 2025,17.88
+555,Vicente,Yañez,M1 4 Moraleja 2025,16.03
+555,Vicente,Yañez,M1 Invierno Ad.26,35.15
+555,Vicente,Yañez,M2 1 Moraleja 2025,4.93
+555,Vicente,Yañez,M2 4 Moraleja 2025,9.25
+555,Vicente,Yañez,M2 5 Moraleja 2025,12.33
+558,Rocío,Cáceres,M1 1 Moraleja 2025,27.55
+558,Rocío,Cáceres,M1 2 Moraleja 2025,24.7
+558,Rocío,Cáceres,M1 4 Moraleja 2025,24.7
+558,Rocío,Cáceres,M2 1 Moraleja 2025,7.6
+558,Rocío,Cáceres,M2 4 Moraleja 2025,14.25
+558,Rocío,Cáceres,M2 5 Moraleja 2025,19.0
+534,Martina,Garrido,M1 1 Moraleja 2025,23.2
+534,Martina,Garrido,M1 2 Moraleja 2025,20.8
+534,Martina,Garrido,M1 4 Moraleja 2025,20.8
+534,Martina,Garrido,M2 1 Moraleja 2025,6.4
+534,Martina,Garrido,M2 4 Moraleja 2025,12.0
+534,Martina,Garrido,M2 5 Moraleja 2025,16.0

--- a/resumen_rendiciones.csv
+++ b/resumen_rendiciones.csv
@@ -1,0 +1,253 @@
+StudentID,FirstName,LastName,Exam,Status,Score
+502,Gabriela Paz,Acuña,M1 1 Moraleja 2025,R,29.0
+502,Gabriela Paz,Acuña,M1 2 Moraleja 2025,R,26.0
+502,Gabriela Paz,Acuña,M1 4 Moraleja 2025,NR,
+502,Gabriela Paz,Acuña,M1 Invierno Ad.26,R,57.0
+502,Gabriela Paz,Acuña,M2 1 Moraleja 2025,R,8.0
+502,Gabriela Paz,Acuña,M2 4 Moraleja 2025,NR,
+502,Gabriela Paz,Acuña,M2 5 Moraleja 2025,NR,
+503,Cristoba,Arriagada,M1 1 Moraleja 2025,R,42.0
+503,Cristoba,Arriagada,M1 2 Moraleja 2025,NR,
+503,Cristoba,Arriagada,M1 4 Moraleja 2025,NR,
+503,Cristoba,Arriagada,M1 Invierno Ad.26,R,51.0
+503,Cristoba,Arriagada,M2 1 Moraleja 2025,R,15.0
+503,Cristoba,Arriagada,M2 4 Moraleja 2025,NR,
+503,Cristoba,Arriagada,M2 5 Moraleja 2025,NR,
+524,Joshua Adolfo,Bravo,M1 1 Moraleja 2025,R,31.0
+524,Joshua Adolfo,Bravo,M1 2 Moraleja 2025,R,27.0
+524,Joshua Adolfo,Bravo,M1 4 Moraleja 2025,R,26.0
+524,Joshua Adolfo,Bravo,M1 Invierno Ad.26,R,47.0
+524,Joshua Adolfo,Bravo,M2 1 Moraleja 2025,NR,
+524,Joshua Adolfo,Bravo,M2 4 Moraleja 2025,NR,
+524,Joshua Adolfo,Bravo,M2 5 Moraleja 2025,NR,
+505,Agustina Belén,Carrera,M1 1 Moraleja 2025,R,34.0
+505,Agustina Belén,Carrera,M1 2 Moraleja 2025,NR,
+505,Agustina Belén,Carrera,M1 4 Moraleja 2025,NR,
+505,Agustina Belén,Carrera,M1 Invierno Ad.26,R,50.0
+505,Agustina Belén,Carrera,M2 1 Moraleja 2025,NR,
+505,Agustina Belén,Carrera,M2 4 Moraleja 2025,NR,
+505,Agustina Belén,Carrera,M2 5 Moraleja 2025,NR,
+508,Isidora Paz,Catalán,M1 1 Moraleja 2025,R,13.0
+508,Isidora Paz,Catalán,M1 2 Moraleja 2025,R,12.0
+508,Isidora Paz,Catalán,M1 4 Moraleja 2025,NR,
+508,Isidora Paz,Catalán,M1 Invierno Ad.26,R,34.0
+508,Isidora Paz,Catalán,M2 1 Moraleja 2025,NR,
+508,Isidora Paz,Catalán,M2 4 Moraleja 2025,NR,
+508,Isidora Paz,Catalán,M2 5 Moraleja 2025,NR,
+514,Juan Esteban,Cruz,M1 1 Moraleja 2025,R,40.0
+514,Juan Esteban,Cruz,M1 2 Moraleja 2025,NR,
+514,Juan Esteban,Cruz,M1 4 Moraleja 2025,NR,
+514,Juan Esteban,Cruz,M1 Invierno Ad.26,R,57.0
+514,Juan Esteban,Cruz,M2 1 Moraleja 2025,NR,
+514,Juan Esteban,Cruz,M2 4 Moraleja 2025,NR,
+514,Juan Esteban,Cruz,M2 5 Moraleja 2025,NR,
+511,Josefa,Fontecilla,M1 1 Moraleja 2025,R,34.0
+511,Josefa,Fontecilla,M1 2 Moraleja 2025,R,37.0
+511,Josefa,Fontecilla,M1 4 Moraleja 2025,NR,
+511,Josefa,Fontecilla,M1 Invierno Ad.26,R,49.0
+511,Josefa,Fontecilla,M2 1 Moraleja 2025,NR,
+511,Josefa,Fontecilla,M2 4 Moraleja 2025,NR,
+511,Josefa,Fontecilla,M2 5 Moraleja 2025,NR,
+528,Ignacia Isabela,Galleguillos,M1 1 Moraleja 2025,R,18.0
+528,Ignacia Isabela,Galleguillos,M1 2 Moraleja 2025,R,15.0
+528,Ignacia Isabela,Galleguillos,M1 4 Moraleja 2025,NR,
+528,Ignacia Isabela,Galleguillos,M1 Invierno Ad.26,NR,
+528,Ignacia Isabela,Galleguillos,M2 1 Moraleja 2025,R,15.0
+528,Ignacia Isabela,Galleguillos,M2 4 Moraleja 2025,R,15.0
+528,Ignacia Isabela,Galleguillos,M2 5 Moraleja 2025,R,20.0
+506,Alejandra,García,M1 1 Moraleja 2025,R,30.0
+506,Alejandra,García,M1 2 Moraleja 2025,NR,
+506,Alejandra,García,M1 4 Moraleja 2025,NR,
+506,Alejandra,García,M1 Invierno Ad.26,R,50.0
+506,Alejandra,García,M2 1 Moraleja 2025,NR,
+506,Alejandra,García,M2 4 Moraleja 2025,NR,
+506,Alejandra,García,M2 5 Moraleja 2025,NR,
+513,Josefina Andrea,Gutierrez,M1 1 Moraleja 2025,R,28.0
+513,Josefina Andrea,Gutierrez,M1 2 Moraleja 2025,NR,
+513,Josefina Andrea,Gutierrez,M1 4 Moraleja 2025,NR,
+513,Josefina Andrea,Gutierrez,M1 Invierno Ad.26,R,49.0
+513,Josefina Andrea,Gutierrez,M2 1 Moraleja 2025,NR,
+513,Josefina Andrea,Gutierrez,M2 4 Moraleja 2025,NR,
+513,Josefina Andrea,Gutierrez,M2 5 Moraleja 2025,NR,
+527,Javier Alejando,Huechucura,M1 1 Moraleja 2025,R,16.0
+527,Javier Alejando,Huechucura,M1 2 Moraleja 2025,NR,
+527,Javier Alejando,Huechucura,M1 4 Moraleja 2025,NR,
+527,Javier Alejando,Huechucura,M1 Invierno Ad.26,NR,
+527,Javier Alejando,Huechucura,M2 1 Moraleja 2025,NR,
+527,Javier Alejando,Huechucura,M2 4 Moraleja 2025,NR,
+527,Javier Alejando,Huechucura,M2 5 Moraleja 2025,NR,
+525,Agustina Paz,Larenas,M1 1 Moraleja 2025,R,21.0
+525,Agustina Paz,Larenas,M1 2 Moraleja 2025,NR,
+525,Agustina Paz,Larenas,M1 4 Moraleja 2025,NR,
+525,Agustina Paz,Larenas,M1 Invierno Ad.26,NR,
+525,Agustina Paz,Larenas,M2 1 Moraleja 2025,NR,
+525,Agustina Paz,Larenas,M2 4 Moraleja 2025,NR,
+525,Agustina Paz,Larenas,M2 5 Moraleja 2025,NR,
+509,Simón Augusto,Lazo,M1 1 Moraleja 2025,R,34.0
+509,Simón Augusto,Lazo,M1 2 Moraleja 2025,NR,
+509,Simón Augusto,Lazo,M1 4 Moraleja 2025,NR,
+509,Simón Augusto,Lazo,M1 Invierno Ad.26,NR,
+509,Simón Augusto,Lazo,M2 1 Moraleja 2025,NR,
+509,Simón Augusto,Lazo,M2 4 Moraleja 2025,NR,
+509,Simón Augusto,Lazo,M2 5 Moraleja 2025,NR,
+553,Paula,Lizana,M1 1 Moraleja 2025,R,45.0
+553,Paula,Lizana,M1 2 Moraleja 2025,R,39.0
+553,Paula,Lizana,M1 4 Moraleja 2025,NR,
+553,Paula,Lizana,M1 Invierno Ad.26,NR,
+553,Paula,Lizana,M2 1 Moraleja 2025,R,20.0
+553,Paula,Lizana,M2 4 Moraleja 2025,R,37.0
+553,Paula,Lizana,M2 5 Moraleja 2025,R,37.0
+510,Trinidad Renata,Lorca,M1 1 Moraleja 2025,R,30.0
+510,Trinidad Renata,Lorca,M1 2 Moraleja 2025,R,17.0
+510,Trinidad Renata,Lorca,M1 4 Moraleja 2025,NR,
+510,Trinidad Renata,Lorca,M1 Invierno Ad.26,R,49.0
+510,Trinidad Renata,Lorca,M2 1 Moraleja 2025,NR,
+510,Trinidad Renata,Lorca,M2 4 Moraleja 2025,NR,
+510,Trinidad Renata,Lorca,M2 5 Moraleja 2025,NR,
+501,Florencia Paz,Olguín,M1 1 Moraleja 2025,R,34.0
+501,Florencia Paz,Olguín,M1 2 Moraleja 2025,NR,
+501,Florencia Paz,Olguín,M1 4 Moraleja 2025,NR,
+501,Florencia Paz,Olguín,M1 Invierno Ad.26,R,47.0
+501,Florencia Paz,Olguín,M2 1 Moraleja 2025,NR,
+501,Florencia Paz,Olguín,M2 4 Moraleja 2025,NR,
+501,Florencia Paz,Olguín,M2 5 Moraleja 2025,NR,
+516,Ignacio Andrés,Ortiz,M1 1 Moraleja 2025,R,43.0
+516,Ignacio Andrés,Ortiz,M1 2 Moraleja 2025,R,43.0
+516,Ignacio Andrés,Ortiz,M1 4 Moraleja 2025,NR,
+516,Ignacio Andrés,Ortiz,M1 Invierno Ad.26,R,52.0
+516,Ignacio Andrés,Ortiz,M2 1 Moraleja 2025,NR,
+516,Ignacio Andrés,Ortiz,M2 4 Moraleja 2025,NR,
+516,Ignacio Andrés,Ortiz,M2 5 Moraleja 2025,NR,
+554,Carla,Parraguez,M1 1 Moraleja 2025,R,36.0
+554,Carla,Parraguez,M1 2 Moraleja 2025,NR,
+554,Carla,Parraguez,M1 4 Moraleja 2025,NR,
+554,Carla,Parraguez,M1 Invierno Ad.26,NR,
+554,Carla,Parraguez,M2 1 Moraleja 2025,NR,
+554,Carla,Parraguez,M2 4 Moraleja 2025,NR,
+554,Carla,Parraguez,M2 5 Moraleja 2025,NR,
+550,Santiago,Quilodrán,M1 1 Moraleja 2025,R,57.0
+550,Santiago,Quilodrán,M1 2 Moraleja 2025,R,56.0
+550,Santiago,Quilodrán,M1 4 Moraleja 2025,NR,
+550,Santiago,Quilodrán,M1 Invierno Ad.26,NR,
+550,Santiago,Quilodrán,M2 1 Moraleja 2025,NR,
+550,Santiago,Quilodrán,M2 4 Moraleja 2025,NR,
+550,Santiago,Quilodrán,M2 5 Moraleja 2025,NR,
+551,Sofía,Quilodrán,M1 1 Moraleja 2025,R,56.0
+551,Sofía,Quilodrán,M1 2 Moraleja 2025,R,55.0
+551,Sofía,Quilodrán,M1 4 Moraleja 2025,NR,
+551,Sofía,Quilodrán,M1 Invierno Ad.26,NR,
+551,Sofía,Quilodrán,M2 1 Moraleja 2025,NR,
+551,Sofía,Quilodrán,M2 4 Moraleja 2025,NR,
+551,Sofía,Quilodrán,M2 5 Moraleja 2025,NR,
+552,José,Reyes,M1 1 Moraleja 2025,R,48.0
+552,José,Reyes,M1 2 Moraleja 2025,NR,
+552,José,Reyes,M1 4 Moraleja 2025,NR,
+552,José,Reyes,M1 Invierno Ad.26,NR,
+552,José,Reyes,M2 1 Moraleja 2025,NR,
+552,José,Reyes,M2 4 Moraleja 2025,NR,
+552,José,Reyes,M2 5 Moraleja 2025,NR,
+533,Martín Ignacio,Robles,M1 1 Moraleja 2025,R,27.0
+533,Martín Ignacio,Robles,M1 2 Moraleja 2025,NR,
+533,Martín Ignacio,Robles,M1 4 Moraleja 2025,NR,
+533,Martín Ignacio,Robles,M1 Invierno Ad.26,R,43.0
+533,Martín Ignacio,Robles,M2 1 Moraleja 2025,NR,
+533,Martín Ignacio,Robles,M2 4 Moraleja 2025,NR,
+533,Martín Ignacio,Robles,M2 5 Moraleja 2025,NR,
+530,Josefa Trinidad,Rojas,M1 1 Moraleja 2025,R,41.0
+530,Josefa Trinidad,Rojas,M1 2 Moraleja 2025,R,49.0
+530,Josefa Trinidad,Rojas,M1 4 Moraleja 2025,NR,
+530,Josefa Trinidad,Rojas,M1 Invierno Ad.26,NR,
+530,Josefa Trinidad,Rojas,M2 1 Moraleja 2025,R,20.0
+530,Josefa Trinidad,Rojas,M2 4 Moraleja 2025,R,39.0
+530,Josefa Trinidad,Rojas,M2 5 Moraleja 2025,R,33.0
+504,Emilia Loreto,Sotelo,M1 1 Moraleja 2025,R,34.0
+504,Emilia Loreto,Sotelo,M1 2 Moraleja 2025,R,30.0
+504,Emilia Loreto,Sotelo,M1 4 Moraleja 2025,NR,
+504,Emilia Loreto,Sotelo,M1 Invierno Ad.26,R,53.0
+504,Emilia Loreto,Sotelo,M2 1 Moraleja 2025,NR,
+504,Emilia Loreto,Sotelo,M2 4 Moraleja 2025,NR,
+504,Emilia Loreto,Sotelo,M2 5 Moraleja 2025,NR,
+532,Antonia,Tobar,M1 1 Moraleja 2025,R,36.0
+532,Antonia,Tobar,M1 2 Moraleja 2025,R,38.0
+532,Antonia,Tobar,M1 4 Moraleja 2025,NR,
+532,Antonia,Tobar,M1 Invierno Ad.26,NR,
+532,Antonia,Tobar,M2 1 Moraleja 2025,R,15.0
+532,Antonia,Tobar,M2 4 Moraleja 2025,R,28.0
+532,Antonia,Tobar,M2 5 Moraleja 2025,NR,
+531,Renato Alonso,Urrucelqui,M1 1 Moraleja 2025,R,32.0
+531,Renato Alonso,Urrucelqui,M1 2 Moraleja 2025,NR,
+531,Renato Alonso,Urrucelqui,M1 4 Moraleja 2025,NR,
+531,Renato Alonso,Urrucelqui,M1 Invierno Ad.26,R,55.0
+531,Renato Alonso,Urrucelqui,M2 1 Moraleja 2025,NR,
+531,Renato Alonso,Urrucelqui,M2 4 Moraleja 2025,NR,
+531,Renato Alonso,Urrucelqui,M2 5 Moraleja 2025,NR,
+517,Agustina Beatriz,Valenzuela,M1 1 Moraleja 2025,R,29.0
+517,Agustina Beatriz,Valenzuela,M1 2 Moraleja 2025,NR,
+517,Agustina Beatriz,Valenzuela,M1 4 Moraleja 2025,R,34.0
+517,Agustina Beatriz,Valenzuela,M1 Invierno Ad.26,R,54.0
+517,Agustina Beatriz,Valenzuela,M2 1 Moraleja 2025,NR,
+517,Agustina Beatriz,Valenzuela,M2 4 Moraleja 2025,NR,
+517,Agustina Beatriz,Valenzuela,M2 5 Moraleja 2025,NR,
+507,Trinidad del Pilar,Vargas,M1 1 Moraleja 2025,R,26.0
+507,Trinidad del Pilar,Vargas,M1 2 Moraleja 2025,R,17.0
+507,Trinidad del Pilar,Vargas,M1 4 Moraleja 2025,NR,
+507,Trinidad del Pilar,Vargas,M1 Invierno Ad.26,R,37.0
+507,Trinidad del Pilar,Vargas,M2 1 Moraleja 2025,NR,
+507,Trinidad del Pilar,Vargas,M2 4 Moraleja 2025,NR,
+507,Trinidad del Pilar,Vargas,M2 5 Moraleja 2025,NR,
+518,Matías Alejandro,Arriagada,M1 1 Moraleja 2025,NR,
+518,Matías Alejandro,Arriagada,M1 2 Moraleja 2025,R,16.0
+518,Matías Alejandro,Arriagada,M1 4 Moraleja 2025,NR,
+518,Matías Alejandro,Arriagada,M1 Invierno Ad.26,NR,
+518,Matías Alejandro,Arriagada,M2 1 Moraleja 2025,NR,
+518,Matías Alejandro,Arriagada,M2 4 Moraleja 2025,NR,
+518,Matías Alejandro,Arriagada,M2 5 Moraleja 2025,NR,
+556,Valentina,Medina,M1 1 Moraleja 2025,NR,
+556,Valentina,Medina,M1 2 Moraleja 2025,R,51.0
+556,Valentina,Medina,M1 4 Moraleja 2025,NR,
+556,Valentina,Medina,M1 Invierno Ad.26,NR,
+556,Valentina,Medina,M2 1 Moraleja 2025,R,30.0
+556,Valentina,Medina,M2 4 Moraleja 2025,NR,
+556,Valentina,Medina,M2 5 Moraleja 2025,NR,
+557,Gaspar,Morales Becerra,M1 1 Moraleja 2025,NR,
+557,Gaspar,Morales Becerra,M1 2 Moraleja 2025,R,19.0
+557,Gaspar,Morales Becerra,M1 4 Moraleja 2025,NR,
+557,Gaspar,Morales Becerra,M1 Invierno Ad.26,R,44.0
+557,Gaspar,Morales Becerra,M2 1 Moraleja 2025,NR,
+557,Gaspar,Morales Becerra,M2 4 Moraleja 2025,NR,
+557,Gaspar,Morales Becerra,M2 5 Moraleja 2025,NR,
+515,Francisca,Ortiz,M1 1 Moraleja 2025,NR,
+515,Francisca,Ortiz,M1 2 Moraleja 2025,R,25.0
+515,Francisca,Ortiz,M1 4 Moraleja 2025,NR,
+515,Francisca,Ortiz,M1 Invierno Ad.26,R,53.0
+515,Francisca,Ortiz,M2 1 Moraleja 2025,NR,
+515,Francisca,Ortiz,M2 4 Moraleja 2025,NR,
+515,Francisca,Ortiz,M2 5 Moraleja 2025,NR,
+526,Josefa Valentina,Quiroga,M1 1 Moraleja 2025,NR,
+526,Josefa Valentina,Quiroga,M1 2 Moraleja 2025,R,41.0
+526,Josefa Valentina,Quiroga,M1 4 Moraleja 2025,R,37.0
+526,Josefa Valentina,Quiroga,M1 Invierno Ad.26,NR,
+526,Josefa Valentina,Quiroga,M2 1 Moraleja 2025,NR,
+526,Josefa Valentina,Quiroga,M2 4 Moraleja 2025,NR,
+526,Josefa Valentina,Quiroga,M2 5 Moraleja 2025,NR,
+555,Vicente,Yañez,M1 1 Moraleja 2025,NR,
+555,Vicente,Yañez,M1 2 Moraleja 2025,R,37.0
+555,Vicente,Yañez,M1 4 Moraleja 2025,NR,
+555,Vicente,Yañez,M1 Invierno Ad.26,NR,
+555,Vicente,Yañez,M2 1 Moraleja 2025,NR,
+555,Vicente,Yañez,M2 4 Moraleja 2025,NR,
+555,Vicente,Yañez,M2 5 Moraleja 2025,NR,
+558,Rocío,Cáceres,M1 1 Moraleja 2025,NR,
+558,Rocío,Cáceres,M1 2 Moraleja 2025,NR,
+558,Rocío,Cáceres,M1 4 Moraleja 2025,NR,
+558,Rocío,Cáceres,M1 Invierno Ad.26,R,57.0
+558,Rocío,Cáceres,M2 1 Moraleja 2025,NR,
+558,Rocío,Cáceres,M2 4 Moraleja 2025,NR,
+558,Rocío,Cáceres,M2 5 Moraleja 2025,NR,
+534,Martina,Garrido,M1 1 Moraleja 2025,NR,
+534,Martina,Garrido,M1 2 Moraleja 2025,NR,
+534,Martina,Garrido,M1 4 Moraleja 2025,NR,
+534,Martina,Garrido,M1 Invierno Ad.26,R,48.0
+534,Martina,Garrido,M2 1 Moraleja 2025,NR,
+534,Martina,Garrido,M2 4 Moraleja 2025,NR,
+534,Martina,Garrido,M2 5 Moraleja 2025,NR,


### PR DESCRIPTION
## Resumen
- Consolidar rendiciones de todos los CSV en `resumen_rendiciones.csv`
- Estimar preguntas correctas para ensayos no rendidos en `proyeccion_preguntas_correctas.csv`
- Documentar nuevos scripts de análisis en README

## Testing
- `python consolidar_rendiciones.py && echo OK`
- `python proyeccion_correctas.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68bf21d022ac8332ab3936fcf4b7625b