### PR TITLE
Direct downloads to csv_ensayos

### DIFF
--- a/descargar/zipgrade_scraper.py
+++ b/descargar/zipgrade_scraper.py
@@ -421,14 +421,9 @@ def open_quiz_and_download(driver, quiz_info, download_dir: Path, dry_run=False)
                 default=None
             )
             if latest:
-                # Move/rename
-                try:
-                    latest.rename(target_path)
-                except Exception:
-                    # Use a unique suffix if a file already exists
-                    suffix = int(time.time())
-                    target_path = download_dir / f"{target_path.stem} ({suffix}){target_path.suffix}"
-                    latest.rename(target_path)
+                if target_path.exists():
+                    target_path.unlink()
+                latest.rename(target_path)
                 print(f"Downloaded: {target_path.name}")
                 return target_path
     raise TimeoutException("Timed out waiting for file to download.")
@@ -516,7 +511,11 @@ def main():
         print("Error: You must set ZIPGRADE_EMAIL and ZIPGRADE_PASSWORD in your environment or .env file.", file=sys.stderr)
         sys.exit(1)
     # Determine download directory
-    download_dir_str = args.download_dir or os.getenv("DOWNLOAD_DIR") or "./zipgrade_downloads"
+    download_dir_str = (
+        args.download_dir
+        or os.getenv("DOWNLOAD_DIR")
+        or str(Path(__file__).resolve().parent.parent / "csv_ensayos")
+    )
     download_dir = Path(download_dir_str).expanduser()
     try:
         download_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- default download path to csv_ensayos in repo root
- overwrite existing CSVs without timestamping when downloading

## Testing
- `python -m py_compile descargar/zipgrade_scraper.py`
- `python - <<'PY'
from pathlib import Path
from descargar import zipgrade_scraper
print(Path(zipgrade_scraper.__file__).resolve().parent.parent / 'csv_ensayos')
PY`
- `python - <<'PY'
from pathlib import Path

download_dir = Path('csv_ensayos')
target_path = download_dir / 'test_file.csv'
(target_path).write_text('old')
latest = download_dir / 'temp_download.csv'
latest.write_text('new')
if target_path.exists():
    target_path.unlink()
latest.rename(target_path)
print('Final content:', target_path.read_text())
PY`
- `ls csv_ensayos | grep test_file`


------
https://chatgpt.com/codex/tasks/task_e_68c2723b7958833295037599943ef153