### PR TITLE
Ensure empty CSV exams appear in summaries

### DIFF
--- a/consolidar_rendiciones.py
+++ b/consolidar_rendiciones.py
@@ -41,7 +41,8 @@ def reunir_datos() -> tuple[dict[str, dict[str, object]], Set[str]]:
             primera = next(reader, None)
 
             if primera is None:
-                examen = ruta.stem.split("-")[1]
+                partes = ruta.stem.split(" - ")
+                examen = partes[1].strip() if len(partes) > 1 else ruta.stem
                 examenes.add(examen)
                 continue
 

--- a/interfaz_rendiciones.py
+++ b/interfaz_rendiciones.py
@@ -40,7 +40,8 @@ def reunir_datos() -> tuple[dict[str, dict[str, object]], Set[str]]:
             reader = csv.DictReader(f)
             primera = next(reader, None)
             if primera is None:
-                examen = ruta.stem.split("-")[1]
+                partes = ruta.stem.split(" - ")
+                examen = partes[1].strip() if len(partes) > 1 else ruta.stem
                 examenes.add(examen)
                 continue
 


### PR DESCRIPTION
## Summary
- Parse exam names from filenames when CSVs are empty so summaries include all exams
- Apply fix to both command-line and GUI summary generators

## Testing
- `python consolidar_rendiciones.py` *(fails: No module named 'pandas')*
- `python -m py_compile consolidar_rendiciones.py interfaz_rendiciones.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3906594188332a0c8eada1b8cc80e