### PR TITLE
Generar CSV individuales por estudiante

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ Los archivos de salida se generan en la raíz del repositorio.
 Recorre todos los archivos dentro de `csv_ensayos/` y genera
 `resumen_rendiciones.csv`, donde cada fila corresponde a un estudiante y
 los nombres de los exámenes aparecen como columnas. En cada celda se
-indica el puntaje obtenido o `NR` si aún no lo ha realizado.
+indica el puntaje obtenido o `NR` si aún no lo ha realizado. Además,
+produce los archivos `resumen_rendiciones.xlsx` y `resumen_rendiciones.pdf`.
+
+Adicionalmente, crea un archivo CSV por estudiante en la carpeta
+`csv_estudiantes/` con todas sus rendiciones y el detalle completo tal
+como aparece en los archivos originales.
 
 ### Uso
 


### PR DESCRIPTION
## Summary
- recopilo el detalle de cada rendición por estudiante al consolidar los CSV de ensayos
- genero archivos CSV individuales en `csv_estudiantes/` con el contenido original y nombres de archivo seguros
- actualicé la documentación para reflejar los nuevos artefactos que produce el script

## Testing
- python consolidar_rendiciones.py *(falla: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68d366946638833287d0214f4da75ff1